### PR TITLE
Fix issue where buttons are visible when FloatingButton is closed

### DIFF
--- a/Sources/FloatingButton/FloatingButton.swift
+++ b/Sources/FloatingButton/FloatingButton.swift
@@ -30,7 +30,7 @@ public struct FloatingButton<MainView, ButtonView>: View where MainView: View, B
     fileprivate var spacing: CGFloat = 10
     fileprivate var initialScaling: CGFloat = 1
     fileprivate var initialOffset: CGPoint = CGPoint()
-    fileprivate var initialOpacity: Double = 1
+    fileprivate var initialOpacity: Double = 0.0
     fileprivate var animation: Animation = .easeInOut(duration: 0.4)
     fileprivate var delays: [Double] = []
     fileprivate var mainZStackAlignment: SwiftUI.Alignment = .center


### PR DESCRIPTION
Fixed #16 by setting the value of initialOpacity to 0.

## Test

### Closed
<img width="302" alt="image" src="https://github.com/exyte/FloatingButton/assets/18320804/43e7d65c-8520-4a21-99f3-48329756ae9a">

### Open
<img width="302" alt="image" src="https://github.com/exyte/FloatingButton/assets/18320804/6131e732-8862-47b2-bb0b-71a493251759">