### PR TITLE
Add ability to present circular menu buttons in a counterclockwise layout

### DIFF
--- a/FloatingButtonExample/FloatingButtonExample/ContentView.swift
+++ b/FloatingButtonExample/FloatingButtonExample/ContentView.swift
@@ -104,6 +104,7 @@ struct ScreenCircle: View {
     var body: some View {
         let mainButton1 = MainButton(imageName: "message.fill", colorHex: "f7b731")
         let mainButton2 = MainButton(imageName: "umbrella.fill", colorHex: "eb3b5a")
+        let mainButton3 = MainButton(imageName: "message.fill", colorHex: "f7b731")
         let buttonsImage = MockData.iconImageNames.enumerated().map { index, value in
             IconButton(imageName: value, color: MockData.colors[index])
         }
@@ -116,6 +117,12 @@ struct ScreenCircle: View {
         let menu2 = FloatingButton(mainButtonView: mainButton1, buttons: buttonsImage)
             .circle()
             .delays(delayDelta: 0.1)
+        let menu3 = FloatingButton(mainButtonView: mainButton3, buttons: buttonsImage.dropLast())
+            .circle()
+            .rotation(.counterclockwise)
+            .startAngle(3/2 * .pi)
+            .endAngle(2 * .pi)
+            .radius(70)
 
         return VStack {
             Spacer()
@@ -124,6 +131,7 @@ struct ScreenCircle: View {
                 Spacer()
                 menu2
                 Spacer()
+                menu3
             }
             .padding(20)
         }

--- a/FloatingButtonExample/FloatingButtonExample/ContentView.swift
+++ b/FloatingButtonExample/FloatingButtonExample/ContentView.swift
@@ -119,7 +119,7 @@ struct ScreenCircle: View {
             .delays(delayDelta: 0.1)
         let menu3 = FloatingButton(mainButtonView: mainButton3, buttons: buttonsImage.dropLast())
             .circle()
-            .rotation(.counterclockwise)
+            .layoutDirection(.counterClockwise)
             .startAngle(3/2 * .pi)
             .endAngle(2 * .pi)
             .radius(70)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ FloatingButton(mainButtonView: mainButton, buttons: buttons, isOpen: $isOpen)
 `startAngle`  
 `endAngle`  
 `radius` - distance between center of main button and centers of submenu buttons  
-`rotation` - changes the button layout direction from the startAngle to the endAngle
+`layoutDirection` - changes the button layout direction from the startAngle to the endAngle
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ FloatingButton(mainButtonView: mainButton, buttons: buttons, isOpen: $isOpen)
         .startAngle(3/2 * .pi)
         .endAngle(2 * .pi)
         .radius(70)
-        .rotation(.counterclockwise)
+        .layoutDirection(.counterClockwise)
     ```
 
 ### Universal options

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ FloatingButton(mainButtonView: mainButton, buttons: buttons, isOpen: $isOpen)
         .startAngle(3/2 * .pi)
         .endAngle(2 * .pi)
         .radius(70)
+        .rotation(.counterclockwise)
     ```
 
 ### Universal options
@@ -70,6 +71,7 @@ FloatingButton(mainButtonView: mainButton, buttons: buttons, isOpen: $isOpen)
 `startAngle`  
 `endAngle`  
 `radius` - distance between center of main button and centers of submenu buttons  
+`rotation` - changes the button layout direction from the startAngle to the endAngle
 
 ## Examples
 

--- a/Sources/FloatingButton/FloatingButton.swift
+++ b/Sources/FloatingButton/FloatingButton.swift
@@ -13,7 +13,7 @@ public enum Direction {
 }
 
 public enum Rotation {
-    case clockwise, counterclockwise
+    case clockwise, counterClockwise
 }
 
 public enum Alignment {
@@ -399,7 +399,7 @@ public extension FloatingButtonGeneric where T: CircleFloatingButton {
         return copy
     }
 
-    func rotation(_ rotation: Rotation) -> FloatingButtonGeneric {
+    func layoutDirection(_ rotation: Rotation) -> FloatingButtonGeneric {
         var copy = self
         copy.floatingButton.rotation = rotation
         return copy

--- a/Sources/FloatingButton/FloatingButton.swift
+++ b/Sources/FloatingButton/FloatingButton.swift
@@ -12,6 +12,10 @@ public enum Direction {
     case left, right, top, bottom
 }
 
+public enum Rotation {
+    case clockwise, counterclockwise
+}
+
 public enum Alignment {
     case left, right, top, bottom, center
 }
@@ -44,6 +48,7 @@ public struct FloatingButton<MainView, ButtonView>: View where MainView: View, B
     fileprivate var alignment: Alignment = .center
     
     // circle
+    fileprivate var rotation: Rotation = .clockwise
     fileprivate var startAngle: Double = .pi
     fileprivate var endAngle: Double = 2 * .pi
     fileprivate var radius: Double?
@@ -228,7 +233,9 @@ public struct FloatingButton<MainView, ButtonView>: View where MainView: View, B
         }
 
         coords = (0..<count).map { i in
-            let angle = (endAngle - startAngle) / Double(count - 1) * Double(i) + startAngle
+            let increment = (endAngle - startAngle) / Double(count - 1) * Double(i)
+            let angle = rotation == .clockwise ? startAngle + increment : startAngle - increment
+            
             return CGPoint(x: radius*cos(angle), y: radius*sin(angle))
         }
 
@@ -391,6 +398,13 @@ public extension FloatingButtonGeneric where T: CircleFloatingButton {
         copy.floatingButton.radius = radius
         return copy
     }
+
+    func rotation(_ rotation: Rotation) -> FloatingButtonGeneric {
+        var copy = self
+        copy.floatingButton.rotation = rotation
+        return copy
+    }
+
 }
 
 struct SubmenuButton<ButtonView: View>: View {

--- a/Sources/FloatingButton/FloatingButton.swift
+++ b/Sources/FloatingButton/FloatingButton.swift
@@ -12,7 +12,7 @@ public enum Direction {
     case left, right, top, bottom
 }
 
-public enum Rotation {
+public enum LayoutDirection {
     case clockwise, counterClockwise
 }
 
@@ -48,7 +48,7 @@ public struct FloatingButton<MainView, ButtonView>: View where MainView: View, B
     fileprivate var alignment: Alignment = .center
     
     // circle
-    fileprivate var rotation: Rotation = .clockwise
+    fileprivate var rotation: LayoutDirection = .clockwise
     fileprivate var startAngle: Double = .pi
     fileprivate var endAngle: Double = 2 * .pi
     fileprivate var radius: Double?
@@ -399,9 +399,9 @@ public extension FloatingButtonGeneric where T: CircleFloatingButton {
         return copy
     }
 
-    func layoutDirection(_ rotation: Rotation) -> FloatingButtonGeneric {
+    func layoutDirection(_ layoutDirection: LayoutDirection) -> FloatingButtonGeneric {
         var copy = self
-        copy.floatingButton.rotation = rotation
+        copy.floatingButton.rotation = layoutDirection
         return copy
     }
 


### PR DESCRIPTION
There is a use case in which presenting circular menu buttons in a counterclockwise fashion is very helpful, especially when the FloatingButton is located at the top of a view instead of the bottom of a view. This change optionally reverses the path and demonstrates the change in the FloatingButtonExample code.